### PR TITLE
pr to fix table hardcode issue

### DIFF
--- a/core/data_manager/strategy/cloud_strategy_impl.py
+++ b/core/data_manager/strategy/cloud_strategy_impl.py
@@ -126,8 +126,8 @@ def _install_mock_wt_sdk_fallbacks() -> None:
         def __init__(
             self,
             db_uri: str = "",
-            landing_table: str = CLOUD_DEV_LANDING_TABLE,
-            serving_table: str = CLOUD_DEV_SERVING_TABLE,
+            landing_table: str = "",
+            serving_table: str = "",
         ):
             self.db_uri = db_uri
             self.landing_table = landing_table
@@ -171,8 +171,6 @@ NON_TRAJECTORY_EVENT_TYPES = {
     "episode_summary",
     "evaluation_summary",
 }
-CLOUD_DEV_LANDING_TABLE = "landing_test"
-CLOUD_DEV_SERVING_TABLE = "serving_test"
 CLOUD_DEV_DATASET_TYPE = "TEST"
 
 
@@ -247,8 +245,8 @@ class CloudStrategy(StorageStrategy):
         self.db_url = str(db_url or "").strip()
         self.job_id = job_id
         self.initialized = False
-        self.landing_table = landing_table or CLOUD_DEV_LANDING_TABLE
-        self.serving_table = serving_table or CLOUD_DEV_SERVING_TABLE
+        self.landing_table = str(landing_table or "").strip() or None
+        self.serving_table = str(serving_table or "").strip() or None
         self.env_config_table = env_config_table
         self.dldb_model = dldb_model
         self.enable_dldb_timing_logs = enable_dldb_timing_logs
@@ -296,8 +294,12 @@ class CloudStrategy(StorageStrategy):
         )
         if self.db_url:
             config.tables.db_uri = self.db_url
-        config.tables.landing_table = self.landing_table
-        config.tables.serving_table = self.serving_table
+        if self.landing_table:
+            config.tables.landing_table = self.landing_table
+        if self.serving_table:
+            config.tables.serving_table = self.serving_table
+        self.landing_table = config.tables.landing_table
+        self.serving_table = config.tables.serving_table
 
         try:
             self.client = WTGatewayClient(config)


### PR DESCRIPTION
修复了safactory无法根据环境配置信息切profile的问题。目前的行为大概是：

- 未传landing_table/serving_table：沿用wt-sdk根据WT_SDK_PROFILE和环境变量解析的表名。
- 显式传入表名：SAfactory覆盖wt-sdk配置。
- 初始化后保存最终解析出的实际表名。
- 删除了默认写死的landing_test/serving_test常量。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud table configuration handling by preserving explicitly configured table names when custom names are not provided.
  * Removed reliance on outdated default cloud table names.
  * Added consistent handling for blank or whitespace-only table name values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->