### PR TITLE
update the task information to the first step

### DIFF
--- a/core/data_manager/manager.py
+++ b/core/data_manager/manager.py
@@ -113,7 +113,8 @@ class DataManager:
         env_state: Optional[str] = None,
         terminated: bool = False,
         truncated: bool = False,
-        is_trainable: bool = True
+        is_trainable: bool = True,
+        dataset: Optional[Any] = None,
     ) -> None:
         """
         Record a single interaction step with full conversation history.
@@ -128,6 +129,7 @@ class DataManager:
             response=response,
             step_reward=step_reward,
             env_state=env_state,
+            dataset=dataset,
             terminated=terminated,
             truncated=truncated,
             is_trainable=is_trainable,

--- a/core/data_manager/strategy/base_strategy.py
+++ b/core/data_manager/strategy/base_strategy.py
@@ -123,6 +123,7 @@ class StorageStrategy(ABC):
         terminated: bool = False,
         truncated: bool = False,
         is_trainable: bool = True,
+        dataset: Optional[Any] = None,
     ) -> None:
         """
         Record a single interaction step with full conversation history.
@@ -144,6 +145,7 @@ class StorageStrategy(ABC):
             terminated: Whether this is a terminal step
             truncated: Whether episode was truncated
             is_trainable: Whether this step is eligible for training
+            dataset: Optional task dataset stored on the first gateway step
         """
         pass
 

--- a/core/data_manager/strategy/cloud_strategy_impl.py
+++ b/core/data_manager/strategy/cloud_strategy_impl.py
@@ -794,6 +794,8 @@ class CloudStrategy(StorageStrategy):
             row["llm_model"] = row.pop("agent_model", None)
             row["env_state"] = _json_object(meta.get("env_state"))
             row["group_id"] = meta.get("group_id")
+            if "dataset" in meta:
+                row["dataset"] = meta["dataset"]
             if row.get("is_trainable") is None:
                 row["is_trainable"] = meta.get("is_trainable", True)
             rows.append(row)

--- a/core/data_manager/strategy/cloud_strategy_impl.py
+++ b/core/data_manager/strategy/cloud_strategy_impl.py
@@ -520,7 +520,8 @@ class CloudStrategy(StorageStrategy):
         env_state: Optional[str] = None,
         terminated: bool = False,
         truncated: bool = False,
-        is_trainable: bool = True
+        is_trainable: bool = True,
+        dataset: Optional[Any] = None,
     ):
         """
         Record step to cloud LandingTable.
@@ -535,6 +536,7 @@ class CloudStrategy(StorageStrategy):
             response=response,
             step_reward=step_reward,
             env_state=env_state,
+            dataset=dataset,
             terminated=terminated,
             truncated=truncated,
             is_trainable=is_trainable,
@@ -622,6 +624,7 @@ class CloudStrategy(StorageStrategy):
         terminated: bool = False,
         truncated: bool = False,
         is_trainable: bool = True,
+        dataset: Optional[Any] = None,
     ) -> tuple[Any, str]:
         session.total_reward += step_reward
 
@@ -662,6 +665,14 @@ class CloudStrategy(StorageStrategy):
             "env_name": session.env_name
         })
         
+        meta_json = {
+            "source": "AIEvoBox",
+            "group_id": session.group_id,
+            "env_state": env_state,
+        }
+        if dataset is not None:
+            meta_json["dataset"] = dataset
+
         # Create LandingRecord
         record = LandingRecord(
             dataset_type=CLOUD_DATASET_TYPE,
@@ -684,11 +695,7 @@ class CloudStrategy(StorageStrategy):
             is_truncated=truncated,
             is_session_completed=terminated or truncated,
             is_trainable=is_trainable,
-            meta_json=json.dumps({
-                "source": "AIEvoBox",
-                "group_id": session.group_id,
-                "env_state": env_state
-            })
+            meta_json=json.dumps(meta_json, ensure_ascii=False, default=str)
         )
         
         return record, record_id

--- a/core/data_manager/strategy/sqlite_strategy_impl.py
+++ b/core/data_manager/strategy/sqlite_strategy_impl.py
@@ -291,7 +291,8 @@ class SqliteStrategy(StorageStrategy):
         env_state: Optional[str] = None,
         terminated: bool = False,
         truncated: bool = False,
-        is_trainable: bool = True
+        is_trainable: bool = True,
+        dataset: Optional[Any] = None,
     ) -> None:
         """
         Record a single interaction step.
@@ -322,6 +323,11 @@ class SqliteStrategy(StorageStrategy):
 
             # Update session's message history
             session.message_history = full_messages
+
+            if dataset is not None:
+                state = _json_object(env_state)
+                state["dataset"] = dataset
+                env_state = json.dumps(state, ensure_ascii=False, default=str)
 
             # Create step record
             step_record = SessionStep(

--- a/gateway/storage.py
+++ b/gateway/storage.py
@@ -31,6 +31,7 @@ class _SessionEnvironment:
     job_id: str
     env_name: str
     group_id: str | None = None
+    dataset: Any = None
 
 
 class GatewayStorage:
@@ -40,6 +41,8 @@ class GatewayStorage:
         self._sessions: dict[tuple[str, str], _CachedSession] = {}
         self._environments: dict[str, _SessionEnvironment] = {}
         self._patched_environment_sessions: set[str] = set()
+        self._dataset_pending_sessions: set[str] = set()
+        self._dataset_written_sessions: set[str] = set()
         self._latest_record_ids: dict[tuple[str, str], str] = {}
         self._lock = asyncio.Lock()
 
@@ -113,13 +116,9 @@ class GatewayStorage:
             return session
 
     async def bind_session_environment(self, binding: GatewaySessionBinding) -> None:
-        if binding.job_id and binding.env_name:
-            log.debug(
-                "Gateway storage bind environment skipped: session_id=%s job_id=%s env_name=%s",
-                binding.session_id,
-                binding.job_id,
-                binding.env_name,
-            )
+        async with self._lock:
+            cached_environment = self._environments.get(binding.session_id)
+        if cached_environment is not None and binding.job_id and binding.env_name:
             return
 
         log.info("Gateway storage resolve environment begin: session_id=%s", binding.session_id)
@@ -225,10 +224,17 @@ class GatewayStorage:
             return None
 
         group_id = environment.get("group_id")
+        env_params = environment.get("env_params")
+        if isinstance(env_params, str):
+            try:
+                env_params = json.loads(env_params)
+            except (TypeError, ValueError):
+                env_params = {}
         return _SessionEnvironment(
             job_id=job_id,
             env_name=env_name,
             group_id=str(group_id) if group_id not in (None, "") else None,
+            dataset=env_params.get("dataset") if isinstance(env_params, dict) else None,
         )
 
     async def _patch_session_steps_environment_once(
@@ -321,6 +327,7 @@ class GatewayStorage:
     ) -> None:
         if not batch:
             return
+        claimed_dataset_sessions: set[str] = set()
         started = time.perf_counter()
         trace = PerfTrace(
             "gateway.storage.record_inference_steps_batch",
@@ -340,23 +347,39 @@ class GatewayStorage:
             with trace.span("session_context.prepare", operation="in_memory"):
                 for binding, record in batch:
                     session = await self.get_or_create_session(binding, record.requested_model)
-                    steps.append(
-                        {
-                            "session": session,
-                            "step_id": record.seq_id,
-                            "messages": _trajectory_messages(record),
-                            "response": "",
-                            "step_reward": 0.0,
-                            "env_state": json.dumps(self._metadata(record), ensure_ascii=False, default=str),
-                            "terminated": False,
-                            "truncated": record.is_truncated,
-                            "is_trainable": False,
-                        }
-                    )
+                    environment = await self._resolve_session_environment(record.session_id)
+                    dataset = environment.dataset if environment is not None else None
+                    attach_dataset = False
+                    if dataset is not None and record.seq_id == 1:
+                        async with self._lock:
+                            if (
+                                record.session_id not in self._dataset_pending_sessions
+                                and record.session_id not in self._dataset_written_sessions
+                            ):
+                                self._dataset_pending_sessions.add(record.session_id)
+                                claimed_dataset_sessions.add(record.session_id)
+                                attach_dataset = True
+
+                    step = {
+                        "session": session,
+                        "step_id": record.seq_id,
+                        "messages": _trajectory_messages(record),
+                        "response": "",
+                        "step_reward": 0.0,
+                        "env_state": json.dumps(self._metadata(record), ensure_ascii=False, default=str),
+                        "terminated": False,
+                        "truncated": record.is_truncated,
+                        "is_trainable": False,
+                    }
+                    if attach_dataset:
+                        step["dataset"] = dataset
+                    steps.append(step)
             with trace.span("storage.record_steps_batch", table="session_steps"):
                 record_ids = await self.data_manager.record_steps_batch(steps)
 
             async with self._lock:
+                self._dataset_pending_sessions.difference_update(claimed_dataset_sessions)
+                self._dataset_written_sessions.update(claimed_dataset_sessions)
                 for (_, record), record_id in zip(batch, record_ids):
                     if record_id:
                         self._latest_record_ids[(record.session_id, record.requested_model)] = record_id
@@ -368,9 +391,13 @@ class GatewayStorage:
             )
             trace.emit_summary(status="success", elapsed_ms=elapsed_ms)
         except asyncio.CancelledError:
+            async with self._lock:
+                self._dataset_pending_sessions.difference_update(claimed_dataset_sessions)
             trace.emit_summary(status="cancelled", error_type="CancelledError")
             raise
         except Exception as exc:
+            async with self._lock:
+                self._dataset_pending_sessions.difference_update(claimed_dataset_sessions)
             trace.emit_summary(status="failed", error_type=type(exc).__name__, error=str(exc))
             raise
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session recording can now persist and return associated dataset information, attached to the first step of each session.
  - Added the ability to list persisted session steps in trajectory order, including deterministic retrieval for cloud-backed storage.

- **Bug Fixes**
  - Improved session environment binding by reusing already-resolved session context when binding details are present.
  - Added safer dataset-attachment coordination during batch step recording, including cleanup on cancellations and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->