### PR TITLE
update wt-sdk tag to include dldb multi version issue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Evaluation dynamically discovers `<agent-root>/<env_name>/rule_evaluator.py` by 
 
 Safactory can optionally persist trajectory and environment data to an S3-backed LanceDB data platform through `wt-data-platform-sdk`. SQLite remains the default local strategy; cloud dependencies are kept separately in `requirements-cloud.txt`.
 
+The optional LanceDB/cloud dependency stack requires Python 3.10-3.12. Python 3.12 is the currently verified environment.
+
 Install the optional dependencies:
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -189,6 +189,8 @@ python launcher.py \
 
 Safactory 可以通过 `wt-data-platform-sdk` 将轨迹和环境数据持久化到以 S3 为对象存储、LanceDB 为数据引擎的存储平台。SQLite 仍是默认的本地存储策略；云存储相关依赖单独维护在 `requirements-cloud.txt` 中。
 
+可选的 LanceDB/cloud 依赖栈要求使用 Python 3.10-3.12，当前已验证的环境为 Python 3.12。
+
 安装可选依赖：
 
 ```bash

--- a/requirements-cloud.txt
+++ b/requirements-cloud.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
-# Cloud storage depends on the private wt-data-gateway repository.
-# Install this file only when you have access to the Gitee project.
-wt-data-platform-sdk @ git+https://gitee.pjlab.org.cn/L2/safeai/Wind-Tunnel/renwuwu---jizuoxitong/wt-data-gateway.git@perfTuning
+# The optional cloud storage stack supports Python 3.10 through 3.12.
+# Pin wt-data-platform-sdk so LanceDB dependencies remain reproducible.
+wt-data-platform-sdk @ git+https://github.com/AI45Lab/wt-data-platform-sdk.git@v0.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Python version requirements for optional S3 and LanceDB storage setup.
  * Clarified that Python 3.12 is the currently verified environment in English and Chinese guides.

* **Chores**
  * Updated cloud dependency installation guidance for reproducible setup with Python 3.10–3.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->