### PR TITLE
datamanager should not directly access the S3 DB with creating a session , change it to use wt-data-gateway instead

### DIFF
--- a/core/data_manager/manager.py
+++ b/core/data_manager/manager.py
@@ -145,9 +145,32 @@ class DataManager:
         """Mark known records completed without a latest-row lookup."""
         return await self.strategy.mark_records_completed(record_ids)
 
-    async def list_session_steps(self, session_id: str) -> List[Dict[str, Any]]:
+    async def list_session_steps(
+        self,
+        session_id: str,
+        *,
+        checkout_latest: bool = False,
+    ) -> List[Dict[str, Any]]:
         """Return persisted rows for one session in trajectory order."""
-        return await self.strategy.list_session_steps(session_id)
+        return await self.strategy.list_session_steps(
+            session_id,
+            checkout_latest=checkout_latest,
+        )
+
+    async def record_evaluation_summary(
+        self,
+        session_id: str,
+        step_id: int,
+        reward: float,
+        env_state: str,
+    ) -> int:
+        """Persist a non-trainable evaluation summary row."""
+        return await self.strategy.record_evaluation_summary(
+            session_id=session_id,
+            step_id=step_id,
+            reward=reward,
+            env_state=env_state,
+        )
 
     async def update_session_step(
         self,

--- a/core/data_manager/strategy/base_strategy.py
+++ b/core/data_manager/strategy/base_strategy.py
@@ -167,15 +167,31 @@ class StorageStrategy(ABC):
         """Mark known records completed without discovering them by a table scan."""
         return 0
 
-    async def list_session_steps(self, session_id: str) -> List[Dict[str, Any]]:
+    async def list_session_steps(
+        self,
+        session_id: str,
+        *,
+        checkout_latest: bool = False,
+    ) -> List[Dict[str, Any]]:
         """
         Return persisted rows for one session in trajectory order.
 
         Storage backends may override this when callers such as evaluators need
-        storage-agnostic access to the completed trajectory.  The default keeps
-        older/custom strategies compatible.
+        storage-agnostic access to the completed trajectory. Cloud callers can
+        request the latest table version when another process performed writes.
+        The default keeps older/custom strategies compatible.
         """
         return []
+
+    async def record_evaluation_summary(
+        self,
+        session_id: str,
+        step_id: int,
+        reward: float,
+        env_state: str,
+    ) -> int:
+        """Persist a non-trainable evaluation result when no trajectory row exists."""
+        return 0
 
     @abstractmethod
     async def update_session_step(

--- a/core/data_manager/strategy/cloud_strategy_impl.py
+++ b/core/data_manager/strategy/cloud_strategy_impl.py
@@ -850,7 +850,7 @@ class CloudStrategy(StorageStrategy):
         ]
         frame = await self._timed_db_call(
             "filter_landing",
-            self.client.query_landing,
+            self.client.query_data,
             filter_query=query,
             limit=10000,
             columns=columns,
@@ -961,12 +961,12 @@ class CloudStrategy(StorageStrategy):
 
         rows = await self._timed_db_call(
             "filter_landing",
-            self.client.query_landing,
+            self.client.query_data,
             filter_query=query,
             limit=1000,
             columns=["step_id", "is_session_completed", "meta_json", "agent_model"],
             partition=job_id or None,
-            checkout_latest=False,
+            checkout_latest=True,
             as_dataframe=True,
             trace_context={"session_id": session_id, "model": llm_model},
         )
@@ -1153,7 +1153,7 @@ class CloudStrategy(StorageStrategy):
                 "falling back to an all-bucket HASH query"
             )
         try:
-            df = self.client.query_landing(
+            df = self.client.query_data(
                 filter_query=filter_query,
                 limit=1,
                 columns=["meta_json"],

--- a/core/data_manager/strategy/cloud_strategy_impl.py
+++ b/core/data_manager/strategy/cloud_strategy_impl.py
@@ -276,6 +276,7 @@ class CloudStrategy(StorageStrategy):
         # In-memory caches
         self._env_configs: Dict[str, Dict] = {}
         self._sessions: Dict[str, SessionContext] = {}
+        self._record_job_ids: Dict[str, str] = {}
 
         # Local fallback directory for failed uploads
         self._local_fallback_dir = "saved_images"
@@ -559,6 +560,8 @@ class CloudStrategy(StorageStrategy):
                 log.error("Failed to ingest step %d: %s", step_id, e)
                 raise
 
+        if record_id and session.job_id:
+            self._record_job_ids[record_id] = str(session.job_id)
         return record_id
 
     async def record_steps_batch(self, steps: List[Dict[str, Any]]) -> List[Optional[str]]:
@@ -589,10 +592,14 @@ class CloudStrategy(StorageStrategy):
                 log.error("Failed to ingest %d cloud steps as a batch: %s", len(records), e)
                 raise
 
+        for record, record_id in zip(records, record_ids):
+            job_id = getattr(record, "job_id", None)
+            if record_id and job_id:
+                self._record_job_ids[record_id] = str(job_id)
         return record_ids
 
     async def mark_records_completed(self, record_ids: List[str]) -> int:
-        """Mark known landing record IDs completed without scanning session rows."""
+        """Mark known landing record IDs completed in their associated HASH buckets."""
         await self.init()
         unique_ids = list(dict.fromkeys(str(record_id) for record_id in record_ids if record_id))
         if not unique_ids:
@@ -600,17 +607,63 @@ class CloudStrategy(StorageStrategy):
         if self._enable_buffer:
             await self._flush_records()
 
-        quoted_ids = ", ".join(f"'{_escape_sql_literal(record_id)}'" for record_id in unique_ids)
-        await self._timed_db_call(
-            "update_landing",
-            self.client.update_landing,
-            f"id IN ({quoted_ids})",
-            {
-                "is_session_completed": True,
-                "is_terminal": True,
-            },
-            trace_context={"record_count": len(unique_ids)},
-        )
+        ids_by_job: Dict[str, List[str]] = {}
+        inferred_ids: List[str] = []
+        missing_job_ids: List[str] = []
+        for record_id in unique_ids:
+            job_id = self._record_job_ids.get(record_id)
+            if not job_id and self.job_id:
+                job_id = str(self.job_id)
+                inferred_ids.append(record_id)
+            if not job_id:
+                missing_job_ids.append(record_id)
+                continue
+            ids_by_job.setdefault(job_id, []).append(record_id)
+
+        if inferred_ids:
+            log.warning(
+                "Record-to-job association unavailable for %d landing records; "
+                "falling back to configured job_id=%s",
+                len(inferred_ids),
+                self.job_id,
+            )
+        if missing_job_ids:
+            log.error(
+                "Cannot mark %d landing records completed without job_id; "
+                "refusing an all-bucket HASH update",
+                len(missing_job_ids),
+            )
+            raise ValueError(
+                "job_id is required to mark landing records completed without "
+                "scanning all HASH buckets"
+            )
+
+        for job_id, job_record_ids in ids_by_job.items():
+            quoted_ids = ", ".join(
+                f"'{_escape_sql_literal(record_id)}'"
+                for record_id in job_record_ids
+            )
+            filter_query = (
+                f"job_id = '{_escape_sql_literal(job_id)}' "
+                f"AND id IN ({quoted_ids})"
+            )
+            await self._timed_db_call(
+                "update_landing",
+                self.client.update_landing,
+                filter_query,
+                {
+                    "is_session_completed": True,
+                    "is_terminal": True,
+                },
+                partition=job_id,
+                trace_context={
+                    "job_id": job_id,
+                    "record_count": len(job_record_ids),
+                },
+            )
+            for record_id in job_record_ids:
+                self._record_job_ids.pop(record_id, None)
+
         log.debug("Marked %d known cloud records completed", len(unique_ids))
         return len(unique_ids)
 
@@ -717,9 +770,18 @@ class CloudStrategy(StorageStrategy):
             await self._flush_records()
 
         filter_query = self._build_session_step_filter(session_id, step_id)
+        job_id = self._job_id_for_session(session_id)
+        if not job_id:
+            log.warning(
+                "Updating landing session step without job_id; "
+                "falling back to an all-bucket HASH update: session_id=%s step_id=%s",
+                session_id,
+                step_id,
+            )
         normalized_updates = self._normalize_session_step_updates_for_cloud(
             updates,
             filter_query=filter_query,
+            job_id=job_id,
         )
         if not normalized_updates:
             return 0
@@ -729,6 +791,7 @@ class CloudStrategy(StorageStrategy):
             self.client.update_landing,
             filter_query,
             normalized_updates,
+            partition=job_id or None,
             trace_context={
                 "session_id": session_id,
                 "step_id": step_id,
@@ -750,11 +813,16 @@ class CloudStrategy(StorageStrategy):
         if self._enable_buffer:
             await self._flush_records()
 
-        session = self._sessions.get(session_id)
-        job_id = session.job_id if session is not None else self.job_id
+        job_id = self._job_id_for_session(session_id)
         clauses = []
         if job_id:
             clauses.append(f"job_id = '{_escape_sql_literal(job_id)}'")
+        else:
+            log.warning(
+                "Reading landing session steps without job_id; "
+                "falling back to an all-bucket HASH query: session_id=%s",
+                session_id,
+            )
         clauses.append(f"session_id = '{_escape_sql_literal(session_id)}'")
         query = " AND ".join(clauses)
         columns = [
@@ -777,12 +845,13 @@ class CloudStrategy(StorageStrategy):
         ]
         frame = await self._timed_db_call(
             "filter_landing",
-            self.client.session.filter,
-            self.client.config.tables.landing_table,
-            query=query,
+            self.client.query_landing,
+            filter_query=query,
             limit=10000,
             columns=columns,
-            partition_cond=None,
+            partition=job_id or None,
+            checkout_latest=False,
+            as_dataframe=True,
             trace_context={"session_id": session_id},
         )
         if frame is None or len(frame) == 0:
@@ -825,10 +894,15 @@ class CloudStrategy(StorageStrategy):
             await self._flush_records()
 
         clauses = []
-        session = self._sessions.get(session_id)
-        job_id = session.job_id if session is not None else self.job_id
+        job_id = self._job_id_for_session(session_id)
         if job_id:
             clauses.append(f"job_id = '{_escape_sql_literal(job_id)}'")
+        else:
+            log.warning(
+                "Reading/updating latest landing session row without job_id; "
+                "falling back to all HASH buckets: session_id=%s",
+                session_id,
+            )
         escaped_session_id = session_id.replace("'", "''")
         clauses.append(f"session_id = '{escaped_session_id}'")
         if llm_model:
@@ -838,12 +912,13 @@ class CloudStrategy(StorageStrategy):
 
         rows = await self._timed_db_call(
             "filter_landing",
-            self.client.session.filter,
-            self.client.config.tables.landing_table,
-            query=query,
+            self.client.query_landing,
+            filter_query=query,
             limit=1000,
             columns=["step_id", "is_session_completed", "meta_json", "agent_model"],
-            partition_cond=None,
+            partition=job_id or None,
+            checkout_latest=False,
+            as_dataframe=True,
             trace_context={"session_id": session_id, "model": llm_model},
         )
         if rows is None or len(rows) == 0:
@@ -887,6 +962,7 @@ class CloudStrategy(StorageStrategy):
                 "is_session_completed": True,
                 "is_terminal": True,
             },
+            partition=job_id or None,
             trace_context={
                 "session_id": session_id,
                 "step_id": latest_step_id,
@@ -931,8 +1007,7 @@ class CloudStrategy(StorageStrategy):
         step_id: int,
         llm_model: Optional[str] = None,
     ) -> str:
-        session = self._sessions.get(session_id)
-        job_id = session.job_id if session is not None else self.job_id
+        job_id = self._job_id_for_session(session_id)
         clauses = []
         if job_id:
             clauses.append(f"job_id = '{_escape_sql_literal(job_id)}'")
@@ -943,11 +1018,17 @@ class CloudStrategy(StorageStrategy):
             clauses.append(f"agent_model = '{_escape_sql_literal(llm_model)}'")
         return " AND ".join(clauses)
 
+    def _job_id_for_session(self, session_id: str) -> str:
+        session = self._sessions.get(session_id)
+        job_id = session.job_id if session is not None else None
+        return str(job_id or self.job_id or "")
+
     def _normalize_session_step_updates_for_cloud(
         self,
         updates: Dict[str, Any],
         *,
         filter_query: str,
+        job_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         if not updates:
             return {}
@@ -1001,21 +1082,35 @@ class CloudStrategy(StorageStrategy):
                 except Exception:
                     meta_json = {"source": "AIEvoBox"}
             else:
-                meta_json = self._load_existing_meta_json(filter_query)
+                meta_json = self._load_existing_meta_json(
+                    filter_query,
+                    job_id=job_id,
+                )
             meta_json.update(meta_updates)
             normalized["meta_json"] = json.dumps(meta_json, ensure_ascii=False)
 
         return normalized
 
-    def _load_existing_meta_json(self, filter_query: str) -> Dict[str, Any]:
+    def _load_existing_meta_json(
+        self,
+        filter_query: str,
+        *,
+        job_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         meta_json: Dict[str, Any] = {"source": "AIEvoBox"}
+        if not job_id:
+            log.warning(
+                "Loading landing meta_json without job_id; "
+                "falling back to an all-bucket HASH query"
+            )
         try:
-            df = self.client.session.filter(
-                self.client.config.tables.landing_table,
-                query=filter_query,
+            df = self.client.query_landing(
+                filter_query=filter_query,
                 limit=1,
                 columns=["meta_json"],
-                partition_cond=None,
+                partition=job_id or None,
+                checkout_latest=False,
+                as_dataframe=True,
             )
         except Exception as e:
             log.warning("Failed to load existing meta_json before cloud update: %s", e)

--- a/core/data_manager/strategy/cloud_strategy_impl.py
+++ b/core/data_manager/strategy/cloud_strategy_impl.py
@@ -806,7 +806,12 @@ class CloudStrategy(StorageStrategy):
         )
         return 1
 
-    async def list_session_steps(self, session_id: str) -> List[Dict[str, Any]]:
+    async def list_session_steps(
+        self,
+        session_id: str,
+        *,
+        checkout_latest: bool = False,
+    ) -> List[Dict[str, Any]]:
         """Read one cloud-backed session in deterministic trajectory order."""
         await self.init()
 
@@ -850,7 +855,7 @@ class CloudStrategy(StorageStrategy):
             limit=10000,
             columns=columns,
             partition=job_id or None,
-            checkout_latest=False,
+            checkout_latest=checkout_latest,
             as_dataframe=True,
             trace_context={"session_id": session_id},
         )
@@ -881,6 +886,50 @@ class CloudStrategy(StorageStrategy):
             )
         )
         return rows
+
+    async def record_evaluation_summary(
+        self,
+        session_id: str,
+        step_id: int,
+        reward: float,
+        env_state: str,
+    ) -> int:
+        """Persist an evaluation-only row when a session has no trainable step."""
+        await self.init()
+        session = self._sessions.get(session_id)
+        if session is None:
+            job_id = str(self.job_id or "")
+            if not job_id:
+                raise ValueError(
+                    "job_id is required to persist a cloud evaluation summary"
+                )
+            log.warning(
+                "Session context unavailable while recording evaluation summary; "
+                "using configured job_id=%s session_id=%s",
+                job_id,
+                session_id,
+            )
+            session = SessionContext(
+                session_id=session_id,
+                env_id=session_id,
+                env_name="gateway",
+                llm_model="",
+                job_id=job_id,
+            )
+            self._sessions[session_id] = session
+
+        await self.record_step(
+            session=session,
+            step_id=step_id,
+            messages=[],
+            response="",
+            step_reward=reward,
+            env_state=env_state,
+            terminated=True,
+            truncated=False,
+            is_trainable=False,
+        )
+        return 1
 
     async def mark_latest_session_completed(
         self,
@@ -1109,7 +1158,7 @@ class CloudStrategy(StorageStrategy):
                 limit=1,
                 columns=["meta_json"],
                 partition=job_id or None,
-                checkout_latest=False,
+                checkout_latest=True,
                 as_dataframe=True,
             )
         except Exception as e:

--- a/evaluator/reward_committer.py
+++ b/evaluator/reward_committer.py
@@ -90,7 +90,10 @@ class RewardCommitter:
         session_id: str,
         eval_result: EvalResult,
     ) -> None:
-        rows = await self.data_manager.list_session_steps(session_id)
+        rows = await self.data_manager.list_session_steps(
+            session_id,
+            checkout_latest=True,
+        )
         terminal = next(
             (row for row in reversed(rows) if _is_trainable_step(row)),
             None,
@@ -102,9 +105,46 @@ class RewardCommitter:
             terminal is not None,
         )
         if terminal is None:
-            raise RuntimeError(
-                f"Cannot commit cloud evaluation reward: no trainable row for session {session_id}"
+            metadata = self._build_reward_metadata(
+                session_id=session_id,
+                eval_result=eval_result,
             )
+            summary_metadata = _as_eval_summary_metadata(metadata)
+            summary = _existing_eval_summary_row(rows, session_id)
+            if summary is None:
+                recorded = await self.data_manager.record_evaluation_summary(
+                    session_id=session_id,
+                    step_id=_next_step_id(rows),
+                    reward=eval_result.normalized_score_10,
+                    env_state=summary_metadata,
+                )
+            else:
+                recorded = await self.data_manager.update_session_step(
+                    session_id,
+                    int(summary.get("step_id") or 0),
+                    {
+                        "step_reward": eval_result.normalized_score_10,
+                        "reward": eval_result.normalized_score_10,
+                        "env_state": _merge_env_state(
+                            summary.get("env_state"),
+                            summary_metadata,
+                        ),
+                        "is_terminal": True,
+                        "is_session_completed": True,
+                        "is_trainable": False,
+                    },
+                )
+            if recorded <= 0:
+                raise RuntimeError(
+                    "Cannot commit cloud evaluation reward: evaluation summary "
+                    f"was not persisted for {session_id}"
+                )
+            log.info(
+                "EVAL REWARD cloud summary persisted: session=%s step_id=%d",
+                session_id,
+                _next_step_id(rows) if summary is None else int(summary.get("step_id") or 0),
+            )
+            return
 
         metadata = self._build_reward_metadata(
             session_id=session_id,
@@ -287,6 +327,8 @@ def _as_eval_summary_metadata(metadata: str) -> str:
 
 
 def _load_env_state(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
     try:
         parsed = json.loads(value) if value else {}
     except Exception:

--- a/evaluator/trajectory_reader.py
+++ b/evaluator/trajectory_reader.py
@@ -31,7 +31,10 @@ class TrajectoryReader:
 
     async def read_by_session(self, session_id: str) -> Trajectory:
         if self.storage_type == "cloud":
-            rows = await self.data_manager.list_session_steps(session_id)
+            rows = await self.data_manager.list_session_steps(
+                session_id,
+                checkout_latest=True,
+            )
             return self._trajectory_from_rows(session_id, rows)
         return await asyncio.to_thread(self._read_by_session_sync, session_id)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation results can now be saved when no trainable trajectory step exists.
  * Session-step views can retrieve the latest available state.
  * Cloud records are more reliably associated with their processing jobs.

* **Bug Fixes**
  * Improved cloud reward commits, completion updates, and session queries.
  * Environment state data is handled consistently during reward recording.
  * Evaluation summaries now preserve reward, metadata, and completion details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->