### PR TITLE
refactor the response information when saving it into db, just keep the content instead of all the response

### DIFF
--- a/gateway/storage.py
+++ b/gateway/storage.py
@@ -360,12 +360,23 @@ class GatewayStorage:
                                 claimed_dataset_sessions.add(record.session_id)
                                 attach_dataset = True
 
+                    stored_response = record.response
+                    if self.cfg.storage_type == "cloud":
+                        response_body = _json_loads(record.response)
+                        try:
+                            content = response_body["choices"][0]["message"]["content"]
+                        except (TypeError, KeyError, IndexError):
+                            pass
+                        else:
+                            if isinstance(content, str) or content is None:
+                                stored_response = content or ""
+
                     step = {
                         "session": session,
                         "step_id": record.seq_id,
                         "messages": _trajectory_messages(record),
                         "request": record.request,
-                        "response": record.response,
+                        "response": stored_response,
                         "step_reward": 0.0,
                         "env_state": json.dumps(self._metadata(record), ensure_ascii=False, default=str),
                         "terminated": False,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud-stored inference responses are now normalized to retain the generated message content when available.
  * Original responses are preserved when data is malformed or incompatible.
  * Non-cloud storage behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->