### PR TITLE
update wt-sdk tag to adopt json schema related db change

### DIFF
--- a/requirements-cloud.txt
+++ b/requirements-cloud.txt
@@ -2,4 +2,4 @@
 
 # The optional cloud storage stack supports Python 3.10 through 3.12.
 # Pin wt-data-platform-sdk so LanceDB dependencies remain reproducible.
-wt-data-platform-sdk @ git+https://github.com/AI45Lab/wt-data-platform-sdk.git@v0.2.0
+wt-data-platform-sdk @ git+https://github.com/AI45Lab/wt-data-platform-sdk.git@v0.3.0


### PR DESCRIPTION
- messages, response, chosen_trace, and rejected_trace must now be supplied as JSON strings when writing records.
- These fields are returned as JSON strings by default; pass deserialize_json=True to receive Python dict/list values.
- maintain_landing_indexes() and scripts/ops/maintain_landing_indexes.py have been replaced by the table-aware maintain_table_indexes() interface.
- Update readme.

All these above mentioned changes have been tested and executed in real s3 lancedb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the cloud SDK to version 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->