### PR TITLE
fix: rebuild the assistant turn from session_steps.response

### DIFF
--- a/rl/buffer_server.py
+++ b/rl/buffer_server.py
@@ -118,6 +118,49 @@ def _required_gateway_base_url() -> str:
     return gateway_base_url
 
 
+def _assistant_message_from_stored_response(response: Any) -> Optional[Dict[str, Any]]:
+    """Rebuild this step's assistant turn from ``session_steps.response``.
+
+    What the column holds depends on the storage backend: the whole chat
+    completion envelope on sqlite, the extracted message on cloud, and plain
+    assistant text on legacy rows. All three resolve to the same turn here.
+
+    The message is returned verbatim. The training-side mask builder compares
+    every non-``content`` key for exact equality against the turn it generated,
+    so neither dropping fields nor synthesizing them is safe -- an unexpected
+    shape must fail loudly instead of matching by luck.
+    """
+    if not response:
+        return None
+
+    payload: Any = response
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            # Legacy rows store the assistant text directly.
+            return {"role": "assistant", "content": response}
+
+    if isinstance(payload, dict):
+        if payload.get("role"):
+            return payload
+        # The sqlite backend persists the whole envelope. Reading the message
+        # back out is what keeps those trajectories trainable at all.
+        choices = payload.get("choices")
+        if isinstance(choices, list):
+            for choice in choices:
+                message = choice.get("message") if isinstance(choice, dict) else None
+                if isinstance(message, dict) and message.get("role"):
+                    return message
+        return None
+    if isinstance(payload, list):
+        return next(
+            (item for item in payload if isinstance(item, dict) and item.get("role")),
+            None,
+        )
+    return None
+
+
 def _build_item_from_row(row: Dict[str, Any]) -> Dict[str, Any]:
     """Convert a database row to the expected item format."""
     # Parse stored prompt (JSON serialized messages list)
@@ -127,13 +170,11 @@ def _build_item_from_row(row: Dict[str, Any]) -> Dict[str, Any]:
     else:
         base_messages = prompt_str
     messages = list(base_messages or [])
-    # Gateway rows already store the assistant response in ``prompt`` as part of
-    # the full trajectory. Legacy rows keep it in the separate response field.
-    # Appending an empty response to gateway rows prevents exact trajectory
-    # matching in the training-side mask builder.
-    response = row.get("response", "")
-    if response:
-        messages.append({"role": "assistant", "content": response})
+    # ``prompt`` holds the request-side history; this step's own assistant turn
+    # lives in ``response``. Relying on it reappearing in a later step's request
+    # would lose the final turn of every trajectory.
+    if assistant := _assistant_message_from_stored_response(row.get("response", "")):
+        messages.append(assistant)
 
     session_id = row.get("session_id", "")
     env_id = row.get("env_id", "")

--- a/rl/slime_generator.py
+++ b/rl/slime_generator.py
@@ -579,6 +579,10 @@ async def generate_rollout_async(args, rollout_id: int, data_buffer, evaluation:
                                     session_id,
                                     group_id,
                                 )
+                                # A stored trajectory that no longer matches what was
+                                # generated starves training while every row still looks
+                                # healthy in the database. Keep it on the dashboard.
+                                metrics.record("dropped/unmatched_trajectory", 1.0, AggType.SUM)
                                 drop_group = True
                                 break
                             if max_length is not None and len(tokens) > max_length:

--- a/tests/rl/test_trajectory_response_contract.py
+++ b/tests/rl/test_trajectory_response_contract.py
@@ -1,0 +1,154 @@
+"""Pins the shape contract between session_steps.response and the RL mask builder.
+
+The training-side mask builder locates a trajectory by matching stored messages
+against the turns it generated, and it compares every non-``content`` key for
+exact equality. That makes the shape of ``session_steps.response`` a correctness
+boundary rather than a storage detail: a mismatch drops whole rollout groups
+behind a single log line. These tests exist so a future change to either side
+fails here instead of silently starving training.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+# rl/buffer_server.py is a service entrypoint: it resolves its log directory at
+# import time, so the root has to exist before the module is loaded. Keep the
+# logs out of the working tree.
+_LOG_ROOT = tempfile.mkdtemp(prefix="safactory-test-")
+os.environ.setdefault("AIEVOBOX_ROOT", _LOG_ROOT)
+
+from rl.buffer_server import _assistant_message_from_stored_response  # noqa: E402
+
+# The text sglang /generate returns, which rl/llm_proxy.py uses both as the mask
+# builder's tree key and as choices[0].message.content of the response it builds.
+ASSISTANT_TEXT = "<think>hypotenuse is 5</think>The answer is 5."
+
+
+def _llm_proxy_response(text: str = ASSISTANT_TEXT) -> str:
+    """The chat-completion body rl/llm_proxy.py synthesizes for a rollout turn."""
+    return json.dumps(
+        {
+            "id": "chatcmpl-session-1",
+            "object": "chat.completion",
+            "model": "proxy",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 7, "total_tokens": 10},
+            "metadata": {"weight_version": 17},
+        }
+    )
+
+
+class StoredResponseRebuildTest(unittest.TestCase):
+    """rl/buffer_server rebuilds this step's assistant turn from the stored row."""
+
+    def test_sqlite_row_resolves_to_the_generated_turn(self) -> None:
+        """The sqlite backend stores the whole envelope in this column."""
+        self.assertEqual(
+            _assistant_message_from_stored_response(_llm_proxy_response()),
+            {"role": "assistant", "content": ASSISTANT_TEXT},
+        )
+
+    def test_cloud_row_resolves_to_the_generated_turn(self) -> None:
+        """The cloud backend stores the extracted message instead."""
+        from gateway.storage import _chat_completion_output
+
+        column = json.dumps(_chat_completion_output(_llm_proxy_response()))
+
+        self.assertEqual(
+            _assistant_message_from_stored_response(column),
+            {"role": "assistant", "content": ASSISTANT_TEXT},
+        )
+
+    def test_legacy_plain_text_row_is_still_understood(self) -> None:
+        self.assertEqual(
+            _assistant_message_from_stored_response(ASSISTANT_TEXT),
+            {"role": "assistant", "content": ASSISTANT_TEXT},
+        )
+
+    def test_multi_choice_output_picks_a_role_bearing_message(self) -> None:
+        column = json.dumps(
+            [
+                {"role": "assistant", "content": "first"},
+                {"role": "assistant", "content": "second"},
+            ]
+        )
+        self.assertEqual(
+            _assistant_message_from_stored_response(column),
+            {"role": "assistant", "content": "first"},
+        )
+
+    def test_nothing_is_appended_when_there_is_no_turn_to_rebuild(self) -> None:
+        for column in ("", None, "null", "{}", json.dumps({"content": "no role"})):
+            with self.subTest(column=column):
+                self.assertIsNone(_assistant_message_from_stored_response(column))
+
+    def test_the_envelope_never_becomes_the_assistant_content(self) -> None:
+        """Regression guard for the bug this contract was written for.
+
+        Appending the column as-is produced an assistant message whose content
+        was a JSON blob, which the mask builder rejected -- dropping the whole
+        rollout group behind one log line.
+        """
+        rebuilt = _assistant_message_from_stored_response(_llm_proxy_response())
+
+        self.assertNotIn("chatcmpl", rebuilt["content"])
+        self.assertNotIn("choices", rebuilt["content"])
+
+
+class MaskBuilderShapeContractTest(unittest.TestCase):
+    """Which assistant shapes the mask builder's prefix match accepts."""
+
+    def setUp(self) -> None:
+        try:
+            from rl.mask.trajectory_mask_builder import TrajectoryMaskBuilder
+        except ImportError as exc:  # torch/transformers are training-side deps
+            self.skipTest(f"mask builder dependencies are not installed: {exc}")
+        # _message_matches needs no tokenizer, so skip __init__.
+        self.builder = TrajectoryMaskBuilder.__new__(TrajectoryMaskBuilder)
+        # The node the builder stores at generation time.
+        self.node = {"role": "assistant", "content": ASSISTANT_TEXT}
+
+    def test_rebuilt_message_matches_the_generated_turn(self) -> None:
+        rebuilt = _assistant_message_from_stored_response(_llm_proxy_response())
+
+        self.assertTrue(self.builder._message_matches(self.node, rebuilt))
+
+    def test_think_blocks_are_ignored_when_comparing_content(self) -> None:
+        self.assertTrue(
+            self.builder._message_matches(
+                self.node, {"role": "assistant", "content": "The answer is 5."}
+            )
+        )
+
+    def test_extra_keys_break_the_match(self) -> None:
+        """Why the rebuilt message must be passed through verbatim.
+
+        Neither dropping these fields nor synthesizing them is safe, so a shape
+        carrying them has to fail here rather than match by luck.
+        """
+        for extra in ("reasoning_content", "tool_calls", "refusal", "think"):
+            with self.subTest(extra=extra):
+                candidate = {
+                    "role": "assistant",
+                    "content": "The answer is 5.",
+                    extra: "anything",
+                }
+                self.assertFalse(self.builder._message_matches(self.node, candidate))
+
+    def test_raw_envelope_does_not_match(self) -> None:
+        candidate = {"role": "assistant", "content": _llm_proxy_response()}
+        self.assertFalse(self.builder._message_matches(self.node, candidate))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

RL rollouts on sqlite drop every group. `session_steps.response` holds the whole chat completion envelope, and `buffer_server` appended that column straight into the trajectory as assistant content. The mask builder matches messages against the turns it generated, so a JSON blob never matches — the group is discarded behind a single warning, while the rows still look healthy in the DB (`is_trainable=1`, non-empty messages).

The append was a deliberate no-op back when this column was always `""`. #35 filled it in, and the no-op became a corruption.

## Changes

- `rl/buffer_server.py` — read the message out of the column, so that the envelope (sqlite), the extracted message (cloud), and plain text (legacy) all resolve to the same turn. The message is returned verbatim: the mask builder compares every non-`content` key for exact equality, so dropping or synthesizing fields would trade a loud failure for a silent mismatch.
- `rl/slime_generator.py` — count drops as `dropped/unmatched_trajectory`.
- `tests/rl/test_trajectory_response_contract.py` — pin the accepted shape in both directions.