### PR TITLE
distinguish the timeout failure which should mark the is_session_completed true

### DIFF
--- a/core/data_manager/manager.py
+++ b/core/data_manager/manager.py
@@ -209,9 +209,11 @@ class DataManager:
         self,
         session_id: str,
         llm_model: Optional[str] = None,
+        *,
+        is_session_completed: bool = True,
     ) -> int:
         """
-        Mark the latest persisted trajectory row for a session as completed.
+        Set the completion state of the latest persisted trajectory row.
         When llm_model is provided, only rows for that model are considered.
 
         Returns the number of updated records.
@@ -219,6 +221,7 @@ class DataManager:
         return await self.strategy.mark_latest_session_completed(
             session_id=session_id,
             llm_model=llm_model,
+            is_session_completed=is_session_completed,
         )
 
     async def close(self) -> None:

--- a/core/data_manager/strategy/base_strategy.py
+++ b/core/data_manager/strategy/base_strategy.py
@@ -229,9 +229,11 @@ class StorageStrategy(ABC):
         self,
         session_id: str,
         llm_model: Optional[str] = None,
+        *,
+        is_session_completed: bool = True,
     ) -> int:
         """
-        Mark the latest persisted trajectory row for a session as completed.
+        Set the completion state of the latest persisted trajectory row.
         When llm_model is provided, only rows for that model are considered.
 
         Returns:

--- a/core/data_manager/strategy/cloud_strategy_impl.py
+++ b/core/data_manager/strategy/cloud_strategy_impl.py
@@ -1013,9 +1013,12 @@ class CloudStrategy(StorageStrategy):
         self,
         session_id: str,
         llm_model: Optional[str] = None,
+        *,
+        is_session_completed: bool = True,
     ) -> int:
-        """Mark the latest cloud-backed trajectory row for a session as completed."""
+        """Set the completion state of the latest cloud-backed trajectory row."""
         await self.init()
+        completed = bool(is_session_completed)
 
         if self._enable_buffer:
             await self._flush_records()
@@ -1073,7 +1076,7 @@ class CloudStrategy(StorageStrategy):
             trajectory_candidates or candidates,
             key=lambda item: item[0],
         )
-        if latest_completed:
+        if completed and latest_completed:
             return 0
 
         update_query = self._build_session_step_filter(
@@ -1086,8 +1089,9 @@ class CloudStrategy(StorageStrategy):
             self.client.update_landing,
             update_query,
             {
-                "is_session_completed": True,
-                "is_terminal": True,
+                "is_session_completed": completed,
+                "is_terminal": completed,
+                **({"step_reward": 0.0, "reward": 0.0} if not completed else {}),
             },
             partition=job_id or None,
             trace_context={

--- a/core/data_manager/strategy/sqlite_strategy_impl.py
+++ b/core/data_manager/strategy/sqlite_strategy_impl.py
@@ -485,9 +485,12 @@ class SqliteStrategy(StorageStrategy):
         self,
         session_id: str,
         llm_model: Optional[str] = None,
+        *,
+        is_session_completed: bool = True,
     ) -> int:
-        """Mark the latest trajectory row for a session as completed."""
+        """Set the completion state of the latest trajectory row for a session."""
         await self.init()
+        completed = bool(is_session_completed)
 
         trace = PerfTrace(
             "sqlite_strategy.mark_latest_session_completed",
@@ -497,6 +500,7 @@ class SqliteStrategy(StorageStrategy):
                 "table": "session_steps",
                 "session_id": session_id,
                 "model": llm_model,
+                "is_session_completed": completed,
                 "buffered": bool(self._write_buffer),
             },
         )
@@ -520,7 +524,7 @@ class SqliteStrategy(StorageStrategy):
                 (step for step in candidates if _is_trajectory_env_state(step.env_state)),
                 candidates[0],
             )
-            if latest.is_session_completed and latest.is_terminal:
+            if completed and latest.is_session_completed and latest.is_terminal:
                 trace.emit_summary(
                     status="skipped",
                     candidate_count=len(candidates),
@@ -530,11 +534,14 @@ class SqliteStrategy(StorageStrategy):
                 )
                 return 0
 
+            updates: Dict[str, Any] = {
+                "is_session_completed": completed,
+                "is_terminal": completed,
+            }
+            if not completed:
+                updates.update(step_reward=0.0, reward=0.0)
             with trace.span("db_write.mark_session_completed", row_id=latest.id, step_id=latest.step_id):
-                updated = await SessionStep.filter(id=latest.id).update(
-                    is_session_completed=True,
-                    is_terminal=True,
-                )
+                updated = await SessionStep.filter(id=latest.id).update(**updates)
             trace.emit_summary(
                 status="success",
                 candidate_count=len(candidates),

--- a/evaluator/gateway_client.py
+++ b/evaluator/gateway_client.py
@@ -26,14 +26,19 @@ class GatewayClient:
         self.retry_backoff_s = max(0.0, float(retry_backoff_s))
         self._client = httpx.AsyncClient(timeout=self.timeout_s)
 
-    async def close_session(self, session_id: str, reason: str) -> None:
+    async def close_session(
+        self,
+        session_id: str,
+        reason: str,
+        completion_mode: str = "complete",
+    ) -> None:
         timeout = httpx.Timeout(self.close_timeout_s, connect=min(self.timeout_s, self.close_timeout_s))
         attempts = self.close_retries + 1
         for attempt in range(1, attempts + 1):
             try:
                 response = await self._client.post(
                     f"{self.gateway_base_url}/{session_id}/close",
-                    json={"reason": reason},
+                    json={"reason": reason, "completion_mode": completion_mode},
                     timeout=timeout,
                 )
                 response.raise_for_status()

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -9,7 +9,7 @@ from contextlib import asynccontextmanager
 from dataclasses import replace
 from typing import Any
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from core.perf_trace import PerfTrace
@@ -652,21 +652,34 @@ def create_app(cfg: GatewayConfig | None = None, storage: GatewayStorage | None 
         resolver: SessionResolver = app.state.gateway_resolver
         telemetry: TelemetryRecorder = app.state.gateway_telemetry
         reason = "gateway_close"
+        completion_mode = "complete"
         try:
             body = await request.json()
-            if isinstance(body, dict) and body.get("reason"):
-                reason = str(body["reason"])
+            if isinstance(body, dict):
+                if body.get("reason"):
+                    reason = str(body["reason"])
+                completion_mode = str(body.get("completion_mode") or completion_mode).strip().lower()
         except Exception:
             pass
+        if completion_mode not in {"complete", "abort"}:
+            raise HTTPException(status_code=400, detail="completion_mode must be 'complete' or 'abort'")
         binding = await resolver.close_session(session_id, reason=reason)
-        log.info("Gateway session close requested: session_id=%s reason=%s", session_id, reason)
+        log.info(
+            "Gateway session close requested: session_id=%s reason=%s completion_mode=%s",
+            session_id,
+            reason,
+            completion_mode,
+        )
         drained = True
         if cfg.close_mode == "soft_close":
             drained = await _wait_for_session_drain(binding, cfg.drain_timeout_s)
 
         telemetry_status = "queued" if telemetry.async_writes_enabled else "flushed"
         try:
-            await telemetry.enqueue_session_close(binding)
+            await telemetry.enqueue_session_close(
+                binding,
+                is_session_completed=completion_mode == "complete",
+            )
         except asyncio.TimeoutError:
             telemetry_status = "timeout"
             log.warning(
@@ -681,6 +694,7 @@ def create_app(cfg: GatewayConfig | None = None, storage: GatewayStorage | None 
             "status": binding.status,
             "drained": drained,
             "telemetry_status": telemetry_status,
+            "completion_mode": completion_mode,
         }
 
     app.add_api_route(

--- a/gateway/storage.py
+++ b/gateway/storage.py
@@ -446,10 +446,14 @@ class GatewayStorage:
         trace = PerfTrace(
             "gateway.storage.record_session_close",
             logger=log,
-            context={"session_id": binding.session_id, "reason": binding.close_reason},
+            context={
+                "session_id": binding.session_id,
+                "reason": binding.close_reason,
+                "is_session_completed": record.is_session_completed,
+            },
         )
         try:
-            if self.cfg.storage_type == "cloud":
+            if self.cfg.storage_type == "cloud" and record.is_session_completed:
                 async with self._lock:
                     record_ids = [
                         record_id
@@ -485,10 +489,11 @@ class GatewayStorage:
                 models = await self._models_for_session(binding)
             trace.update_context(model_count=len(models), models=models)
             log.info(
-                "Gateway storage session_close begin: session_id=%s models=%s reason=%s",
+                "Gateway storage session_close begin: session_id=%s models=%s reason=%s completed=%s",
                 binding.session_id,
                 models,
                 binding.close_reason,
+                record.is_session_completed,
             )
             if not models:
                 with trace.span(
@@ -496,7 +501,10 @@ class GatewayStorage:
                     operation="db_write",
                     table="session_steps",
                 ):
-                    await self.data_manager.mark_latest_session_completed(session_id=binding.session_id)
+                    await self.data_manager.mark_latest_session_completed(
+                        session_id=binding.session_id,
+                        is_session_completed=record.is_session_completed,
+                    )
                 elapsed_ms = (time.perf_counter() - started) * 1000
                 trace.emit_summary(status="success", elapsed_ms=elapsed_ms, updated_without_model=True)
                 log.info(
@@ -519,6 +527,7 @@ class GatewayStorage:
                             self.data_manager.mark_latest_session_completed(
                                 session_id=binding.session_id,
                                 llm_model=model,
+                                is_session_completed=record.is_session_completed,
                             )
                             for model in models
                         )
@@ -535,6 +544,7 @@ class GatewayStorage:
                         updated_count += await self.data_manager.mark_latest_session_completed(
                             session_id=binding.session_id,
                             llm_model=model,
+                            is_session_completed=record.is_session_completed,
                         )
 
             if updated_count == 0:
@@ -543,7 +553,10 @@ class GatewayStorage:
                     operation="db_write",
                     table="session_steps",
                 ):
-                    await self.data_manager.mark_latest_session_completed(session_id=binding.session_id)
+                    await self.data_manager.mark_latest_session_completed(
+                        session_id=binding.session_id,
+                        is_session_completed=record.is_session_completed,
+                    )
             elapsed_ms = (time.perf_counter() - started) * 1000
             log.info(
                 "Gateway storage session_close complete: session_id=%s updated_count=%d elapsed_ms=%.2f",

--- a/gateway/telemetry.py
+++ b/gateway/telemetry.py
@@ -177,7 +177,12 @@ class TelemetryRecorder:
         )
         await self._enqueue(binding, record)
 
-    async def enqueue_session_close(self, binding: GatewaySessionBinding) -> None:
+    async def enqueue_session_close(
+        self,
+        binding: GatewaySessionBinding,
+        *,
+        is_session_completed: bool,
+    ) -> None:
         now = datetime.now(timezone.utc)
         seq_id = await self._next_seq(binding.session_id, binding.model or "")
         record = GatewayTelemetryRecord(
@@ -219,7 +224,7 @@ class TelemetryRecorder:
             completed_at=now,
             max_steps=self.cfg.max_steps,
             is_truncated=binding.truncated,
-            is_session_completed=True,
+            is_session_completed=is_session_completed,
             truncate_reason=binding.truncate_reason,
         )
         await self._enqueue(binding, record)

--- a/manager/rjob_episode_runner.py
+++ b/manager/rjob_episode_runner.py
@@ -224,6 +224,7 @@ class RJobEpisodeRunner:
                     "runtime": "rjob",
                     "rjob_name": submitted_name or rjob_name,
                     "rjob_status": terminal_status,
+                    "timeout_layer": "rjob_wait_terminal",
                     "logs_tail": tail(logs_text),
                 },
             )

--- a/manager/simulation_worker.py
+++ b/manager/simulation_worker.py
@@ -264,16 +264,22 @@ class SimulationWorkerGroup:
                     rollout_reward=result.total_reward,
                     rollout_truncated=result.truncated,
                 )
+                completion_mode = self._gateway_completion_mode(result)
+                trace.update_context(gateway_completion_mode=completion_mode)
                 if self.gateway_client is not None:
                     with trace.span("gateway_finalize"):
                         await self._finalize_gateway_session(
                             result,
+                            completion_mode=completion_mode,
                             worker_id=worker_id,
                             agent_key=agent_key,
                             trace=trace,
                         )
 
-                if self.evaluation_service is None or self.reward_committer is None:
+                if completion_mode == "abort":
+                    result.total_reward = 0.0
+                    release_reusable = False
+                elif self.evaluation_service is None or self.reward_committer is None:
                     release_reusable = False
                 else:
                     with trace.span("eval_discover_rule"):
@@ -454,19 +460,29 @@ class SimulationWorkerGroup:
         self,
         result: SimulationStartResult,
         *,
+        completion_mode: str,
         worker_id: int,
         agent_key: str,
         trace: PerfTrace | None = None,
     ) -> None:
         if self.gateway_client is None:
             return
+        reason = "rollout_finished" if completion_mode == "complete" else "system_error"
         try:
             if trace is None:
-                await self.gateway_client.close_session(result.session_id, reason="rollout_finished")
+                await self.gateway_client.close_session(
+                    result.session_id,
+                    reason=reason,
+                    completion_mode=completion_mode,
+                )
                 await self.gateway_client.wait_telemetry_flush(result.session_id)
             else:
                 with trace.span("gateway_close_session"):
-                    await self.gateway_client.close_session(result.session_id, reason="rollout_finished")
+                    await self.gateway_client.close_session(
+                        result.session_id,
+                        reason=reason,
+                        completion_mode=completion_mode,
+                    )
                 with trace.span("gateway_wait_telemetry_flush"):
                     await self.gateway_client.wait_telemetry_flush(result.session_id)
         except httpx.HTTPError as exc:
@@ -479,6 +495,23 @@ class SimulationWorkerGroup:
                 result.session_id,
                 exc,
             )
+
+    @staticmethod
+    def _gateway_completion_mode(result: SimulationStartResult) -> str:
+        metrics = result.metrics if isinstance(result.metrics, dict) else {}
+        if str(metrics.get("rjob_status") or "") in {"Failed", "Stopped", "Killed"}:
+            return "abort"
+        if result.truncated:
+            return "complete"
+        if str(metrics.get("timeout_layer") or "") in {
+            "docker_exec",
+            "sandbox_command",
+            "rjob_wait_terminal",
+        }:
+            return "complete"
+        if result.status == "succeeded":
+            return "complete"
+        return "abort"
 
     def _build_start_request(
         self,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sessions can now be closed as either **complete** or **aborted**.
  - Session closure responses and records reflect the selected completion status.
  - Invalid completion modes are rejected with a clear error.

- **Bug Fixes**
  - Aborted sessions no longer retain completion rewards or reusable leases.
  - Session progress and reward totals reset when completion is reverted.
  - Timeout reporting now identifies the relevant waiting stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->