### PR TITLE
fix system fragment rendering in trajectory masks

### DIFF
--- a/rl/mask/trajectory_mask_builder.py
+++ b/rl/mask/trajectory_mask_builder.py
@@ -216,11 +216,20 @@ class TrajectoryMaskBuilder:
 
     def _render_message_delta_str(self, model_input_message: Dict[str, Any]) -> str:
         if model_input_message.get("role") == "system":
-            return self.tokenizer.apply_chat_template(
-                [model_input_message],
+            base_user_message = BASE_CHAT_HISTORY[1]
+            with_system_str = self.tokenizer.apply_chat_template(
+                [model_input_message, base_user_message],
                 add_generation_prompt=False,
                 tokenize=False,
             )
+            without_system_str = self.tokenizer.apply_chat_template(
+                [base_user_message],
+                add_generation_prompt=False,
+                tokenize=False,
+            )
+            if not with_system_str.endswith(without_system_str):
+                raise ValueError("failed to extract system-message template fragment")
+            return with_system_str[: -len(without_system_str)]
 
         single_message_chat_template_str = self.tokenizer.apply_chat_template(
             BASE_CHAT_HISTORY + [model_input_message],


### PR DESCRIPTION
## Problem
`TrajectoryMaskBuilder` incrementally renders each message to recover its token span and loss mask. When processing a system message, it previously called:

```python
tokenizer.apply_chat_template([system_message])
```
Some chat templates reject a system-only conversation. With Qwen3.5, this raised:

jinja2.exceptions.TemplateError: No user query found in messages.

## Fix

Render the system message together with a stable user message, then render the same user message independently and subtract the common suffix:

render(system + user) - render(user) = system fragment

This preserves the model-specific system special tokens without requiring the chat template to accept a system-only conversation.