### PR TITLE
add key pool for gateway

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -12,7 +12,7 @@ DEFAULT_SQLITE_DB_URL = "sqlite://env_trajs.db"
 @dataclass(frozen=True)
 class LLMRouteConfig:
     base_url: str
-    api_key: str | None = None
+    api_key: str | list[str] | None = None
     supports_stream: bool = True
     max_concurrency: int | None = None
     anthropic_interleaved_thinking: bool = True

--- a/gateway/llm_router.py
+++ b/gateway/llm_router.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import random
 from dataclasses import dataclass
 
 from gateway.config import GatewayConfig, LLMRouteConfig
 from gateway.models import GatewayRequestContext, GatewaySessionBinding
+
+
+def _pick_api_key(api_key: str | list[str] | None) -> str | None:
+    if isinstance(api_key, list):
+        return random.choice(api_key) if api_key else None
+    return api_key
 
 
 class ModelNotFoundError(Exception):
@@ -80,7 +87,7 @@ class LLMRouter:
         return LLMRouteTarget(
             route_model=requested_model,
             base_url=route.base_url,
-            api_key=route.api_key,
+            api_key=_pick_api_key(route.api_key),
             supports_stream=route.supports_stream,
             max_concurrency=max_concurrency,
             anthropic_interleaved_thinking=route.anthropic_interleaved_thinking,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Routes can now be configured with multiple API keys.
  - A key is selected automatically for each standard route target, with safe handling for empty lists.

- **Bug Fixes**
  - Existing single-key and unset-key configurations continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->